### PR TITLE
change transaction value type to number

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -654,6 +654,6 @@ export interface DepositTransaction {
   contractAddress: string;
   from: string;
   to: string;
-  value: string;
+  value: number;
   txHash: string;
 }


### PR DESCRIPTION
This PR was made due to changes in the Transaction schema of the NFT-server.