### PR TITLE
Add generic return for useItem

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,8 @@ import {
   NftMetadata,
   Item,
   ItemGiveHistory,
+  itemType,
+  UseItemReturnType,
 } from './types';
 
 export default class Store extends AinftBase {
@@ -528,13 +530,13 @@ export default class Store extends AinftBase {
    * @param {object=} ItemUseParams.params - The parameters to send when using the item. It mainly contains NFT information.
    * @returns {Promise<NftMetadata | null>} - A promise that returns the metadata of the used NFT or null if the item is not an NFT trait.
    */
-  useItem({
+  useItem<T extends itemType>({
     appId,
     userId,
     itemName,
     quantity,
     params,
-  }: ItemUseParams): Promise<NftMetadata | null> {
+  }: ItemUseParams): UseItemReturnType[T] {
     const encodedItemName = encodeURIComponent(itemName);
     const body = {
       appId,

--- a/src/store.ts
+++ b/src/store.ts
@@ -522,13 +522,14 @@ export default class Store extends AinftBase {
 
   /**
    * Uses an item
+   * @template T - The itemType.
    * @param {ItemUseParams} ItemUseParams - Parameters for using an item.
    * @param {string} ItemUseParams.appId - The ID of the app.
    * @param {string} ItemUseParams.userId - The ID of the user.
    * @param {string} ItemUseParams.itemName - The name of the item.
    * @param {number} ItemUseParams.quantity - The quantity of item to use.
    * @param {object=} ItemUseParams.params - The parameters to send when using the item. It mainly contains NFT information.
-   * @returns {Promise<NftMetadata | null>} - A promise that returns the metadata of the used NFT or null if the item is not an NFT trait.
+   * @returns {UseItemReturnType[T]} - A Promise representing the retrieved item. The return type is determined based on the itemType.
    */
   useItem<T extends itemType>({
     appId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,18 @@ export enum ItemGiveStatus {
   FAILED = 'FAILED',
 };
 
+export enum itemType {
+  TICKET = 'TICKET',
+  NFT_TRAIT = 'NFT_TRAIT',
+  NFT = 'NFT',
+};
+
+export type UseItemReturnType = {
+  [itemType.TICKET]: Promise<void>,
+  [itemType.NFT_TRAIT]: Promise<NftMetadata>,
+  [itemType.NFT]: Promise<string>,
+};
+
 // Text to Art
 export enum ResponseStatus {
   PENDING = 'pending',


### PR DESCRIPTION
The useItem function has been updated with a generic type parameter T, which represents the itemType to retrieve and use. The return type of the function is determined based on the itemType. The function accepts additional arguments (...args) specific to the itemType.

Example usage:
```
useItem(...) // returns a Promise<void> | Promise<string> | Promise<NftMetadata>.
useItem<itemType.TICKET>(...) // returns a Promise<void>.
useItem<itemType.NFT_TRAIT>(...) // returns a Promise<NftMetadata>.
useItem<itemType.NFT>(...) // returns a Promise<string>.
```
cc: @ehgmsdk20 

