### PR TITLE
Set ain wallet signer & Add AinftToken class

### DIFF
--- a/src/activity.ts
+++ b/src/activity.ts
@@ -68,7 +68,7 @@ export default class Activity extends FactoryBase {
     data,
     label,
   }: AddAiHistoryParams) {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
     const txInput = await this.getTxBodyForAddNftAiHistory({
       chain,
       network,

--- a/src/ainft.ts
+++ b/src/ainft.ts
@@ -15,6 +15,9 @@ import { serializeEndpoint } from './util';
 import { AinWalletSigner } from '@ainblockchain/ain-js/lib/signer/ain-wallet-signer';
 import { Signer } from '@ainblockchain/ain-js/lib/signer/signer';
 
+/**
+ * A class that establishes a blockchain and ainft server connection and initializes other classes.
+ */
 export default class AinftJs {
   private baseUrl: string;
   public nft: Nft;

--- a/src/ainft.ts
+++ b/src/ainft.ts
@@ -12,6 +12,8 @@ import TextToArt from './textToArt';
 import Activity from './activity';
 import { AINFT_SERVER_ENDPOINT, AIN_BLOCKCHAIN_CHAINID, AIN_BLOCKCHAIN_ENDPOINT } from './constants';
 import { serializeEndpoint } from './util';
+import { AinWalletSigner } from '@ainblockchain/ain-js/lib/signer/ain-wallet-signer';
+import { Signer } from '@ainblockchain/ain-js/lib/signer/signer';
 
 export default class AinftJs {
   private baseUrl: string;
@@ -96,6 +98,15 @@ export default class AinftJs {
     // NOTE(liayoo): always have only 1 access account for now
     this.ain.wallet.clear();
     this.ain.wallet.addAndSetDefaultAccount(privateKey);
+  }
+
+  setSigner(signer: Signer) {
+    this.ain.setSigner(signer);
+  }
+
+  setAinWalletSigner() {
+    const signer = new AinWalletSigner();
+    this.setSigner(signer);
   }
 
   /**

--- a/src/ainft721.ts
+++ b/src/ainft721.ts
@@ -1,3 +1,4 @@
+import { AinftToken } from "./ainftToken";
 import FactoryBase from "./factoryBase";
 import { HttpMethod } from "./types";
 import Ain from "@ainblockchain/ain-js";
@@ -9,10 +10,25 @@ interface IAinft721 {
 
 export default class Ainft721 extends FactoryBase implements IAinft721 {
   readonly id: string;
+  readonly name: string;
+  readonly symbol: string;
+  readonly owner: string;
 
-  constructor(id: string, ain: Ain, baseUrl: string) {
+  constructor(nftInfo: { id: string, name: string, symbol: string, owner: string}, ain: Ain, baseUrl: string) {
     super(ain, baseUrl);
-    this.id = id;
+    this.id = nftInfo.id;
+    this.name = nftInfo.name;
+    this.symbol = nftInfo.symbol;
+    this.owner = nftInfo.owner;
+  }
+
+  async get(tokenId: string) {
+    const { list } = await this.sendRequestWithoutSign(HttpMethod.GET, `native/search`, { nftId: this.id, tokenId });
+    if (list.length === 0) {
+      throw new Error('Not found token');
+    }
+    const token = list[0];
+    return new AinftToken({ nftId: this.id, tokenId, tokenURI: token.tokenURI, metadata: token.metadata }, this.ain, this.baseUrl);
   }
 
   async transfer(from: string, to: string, tokenId: string): Promise<any> {
@@ -21,7 +37,7 @@ export default class Ainft721 extends FactoryBase implements IAinft721 {
   }
 
   async mint(to: string, tokenId: string): Promise<any> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
     const txbody = await this.getTxBodyForMint(address, to, tokenId);
     return this.ain.sendTransaction(txbody);
   }

--- a/src/ainft721.ts
+++ b/src/ainft721.ts
@@ -3,12 +3,10 @@ import FactoryBase from "./factoryBase";
 import { HttpMethod } from "./types";
 import Ain from "@ainblockchain/ain-js";
 
-interface IAinft721 {
-  transfer(from: string, to: string, tokenId: string): Promise<any>;
-  mint(to: string, tokenId: string): Promise<any>;
-}
-
-export default class Ainft721 extends FactoryBase implements IAinft721 {
+/**
+ * The class of AINFT 721.
+ */
+export default class Ainft721 extends FactoryBase {
   readonly id: string;
   readonly name: string;
   readonly symbol: string;
@@ -22,6 +20,11 @@ export default class Ainft721 extends FactoryBase implements IAinft721 {
     this.owner = nftInfo.owner;
   }
 
+  /**
+   * Get specific token object.
+   * @param tokenId
+   * @returns 
+   */
   async get(tokenId: string) {
     const { list } = await this.sendRequestWithoutSign(HttpMethod.GET, `native/search`, { nftId: this.id, tokenId });
     if (list.length === 0) {
@@ -31,17 +34,37 @@ export default class Ainft721 extends FactoryBase implements IAinft721 {
     return new AinftToken({ nftId: this.id, tokenId, tokenURI: token.tokenURI, metadata: token.metadata }, this.ain, this.baseUrl);
   }
 
+  /**
+   * Transfer token to others.
+   * @param from 
+   * @param to 
+   * @param tokenId 
+   * @returns 
+   */
   async transfer(from: string, to: string, tokenId: string): Promise<any> {
     const txbody  = await this.getTxBodyForTransfer(from, to, tokenId);
     return this.ain.sendTransaction(txbody);
   }
 
+  /**
+   * Mint new token.
+   * @param to 
+   * @param tokenId 
+   * @returns 
+   */
   async mint(to: string, tokenId: string): Promise<any> {
     const address = await this.ain.signer.getAddress();
     const txbody = await this.getTxBodyForMint(address, to, tokenId);
     return this.ain.sendTransaction(txbody);
   }
 
+  /**
+   * Get txBody to transfer token.
+   * @param from 
+   * @param to 
+   * @param tokenId 
+   * @returns 
+   */
   getTxBodyForTransfer(from: string, to: string, tokenId: string) {
     const body = {
       address: from,
@@ -51,6 +74,13 @@ export default class Ainft721 extends FactoryBase implements IAinft721 {
     return this.sendRequest(HttpMethod.POST, trailingUrl, body);
   }
 
+  /**
+   * Get txBody to mint token.
+   * @param ownerAddress 
+   * @param to 
+   * @param tokenId 
+   * @returns 
+   */
   getTxBodyForMint(ownerAddress: string, to: string, tokenId: string) {
     const body = {
       address: ownerAddress,

--- a/src/ainftToken.ts
+++ b/src/ainftToken.ts
@@ -1,0 +1,27 @@
+import Ain from "@ainblockchain/ain-js";
+import FactoryBase from "./factoryBase";
+import { HttpMethod } from "./types";
+
+export class AinftToken extends FactoryBase {
+  readonly nftId: string;
+  readonly tokenId: string;
+  readonly metadata?: object;
+  readonly tokenURI: string;
+
+  constructor(tokenInfo: {nftId: string, tokenId: string, tokenURI: string, metadata?: object}, ain: Ain, baseUrl: string) {
+    super(ain, baseUrl);
+    this.nftId = tokenInfo.nftId;
+    this.tokenId = tokenInfo.tokenId;
+    this.tokenURI = tokenInfo.tokenURI;
+    this.metadata = tokenInfo.metadata;
+  }
+
+  async setMetadata(metadata: object) { 
+    const address = await this.ain.signer.getAddress();
+    const body = { nftId: this.nftId, tokenId: this.tokenId, metadata, userAddress: address };
+    const trailingUrl = `native/metadata`;
+    const txBody = await this.sendRequestWithoutSign(HttpMethod.POST, trailingUrl, body);
+
+    return this.ain.sendTransaction(txBody);
+  }
+}

--- a/src/ainftToken.ts
+++ b/src/ainftToken.ts
@@ -2,6 +2,9 @@ import Ain from "@ainblockchain/ain-js";
 import FactoryBase from "./factoryBase";
 import { HttpMethod } from "./types";
 
+/**
+ * The class of AINFT Token.
+ */
 export class AinftToken extends FactoryBase {
   readonly nftId: string;
   readonly tokenId: string;
@@ -16,6 +19,11 @@ export class AinftToken extends FactoryBase {
     this.metadata = tokenInfo.metadata;
   }
 
+  /**
+   * Set token's metadata.
+   * @param metadata 
+   * @returns 
+   */
   async setMetadata(metadata: object) { 
     const address = await this.ain.signer.getAddress();
     const body = { nftId: this.nftId, tokenId: this.tokenId, metadata, userAddress: address };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,7 +9,7 @@ export default class Auth extends FactoryBase {
    * @returns
    */
   async createApp(appId: string) {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
     return this.ain.db.ref(`/manage_app/${appId}/create/${Date.now()}`).setValue({
       value: {
         admin: {
@@ -159,7 +159,7 @@ export default class Auth extends FactoryBase {
    * @returns
    */
   async registerBlockchainApp(appId: string, accessAinAddress?: string) {
-    const ownerAddress = this.ain.signer.getAddress();
+    const ownerAddress = await this.ain.signer.getAddress();
     const body = {
       appId,
       ownerAddress,
@@ -176,7 +176,7 @@ export default class Auth extends FactoryBase {
    * @returns
    */
   async getTxBodyForDelegateApp(appId: string) {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
     const body = { appId, address };
     const trailingUrl = `delegate_app`;
     return this.sendRequest(HttpMethod.POST, trailingUrl, body);

--- a/src/nft.ts
+++ b/src/nft.ts
@@ -234,41 +234,16 @@ export default class Nft extends FactoryBase {
    * @returns
    */
   async setNftMetadata({
-    nftId,
-    tokenId,
-    metadata,
-  }: SetAinNftMetadataParams): Promise<any>;
-  async setNftMetadata({
     appId,
     chain,
     network,
     contractAddress,
     tokenId,
     metadata,
-  }: SetEthNftMetadataParams): Promise<NftMetadata>;
-  async setNftMetadata({
-    appId,
-    chain,
-    network,
-    contractAddress,
-    tokenId,
-    metadata,
-    nftId,
-  }: SetNftMetadataParams): Promise<NftMetadata | any> {
-    if (chain === 'ETH') {
-      const body = { appId, metadata };
-      const trailingUrl = `info/${chain}/${network}/${contractAddress}/${tokenId}/metadata`;
-      return this.sendRequest(HttpMethod.POST, trailingUrl, body);
-    } else {
-      const address = await this.ain.signer.getAddress();
-      const txBody = await this.getTxBodyForSetNftMetadata({
-        nftId,
-        tokenId,
-        metadata,
-        userAddress: address
-      });
-      return this.ain.sendTransaction(txBody);
-    }
+  }: SetEthNftMetadataParams): Promise<NftMetadata> {
+    const body = { appId, metadata };
+    const trailingUrl = `info/${chain}/${network}/${contractAddress}/${tokenId}/metadata`;
+    return this.sendRequest(HttpMethod.POST, trailingUrl, body);
   }
 
   /**

--- a/src/nft.ts
+++ b/src/nft.ts
@@ -32,25 +32,16 @@ import stringify from 'fast-json-stable-stringify';
 import {SUPPORTED_AINFT_STANDARDS} from "./constants";
 
 export default class Nft extends FactoryBase {
-
-  private isSupportedStandard(standard: string) {
-    return Object.values(SUPPORTED_AINFT_STANDARDS).includes(standard);
-  }
-
   /**
    * Create NFT. Default standard is 721.
    * @param name NFT name
    * @param symbol NFT symbol
    * @param standard
    */
-  async create(name: string, symbol: string, standard?: string) {
-    if (!standard) standard = SUPPORTED_AINFT_STANDARDS["721"];
-    if (!this.isSupportedStandard(standard)) {
-      throw Error('Nft create: Not supported standard.');
-    }
+  async create(name: string, symbol: string) {
     const address = await this.ain.signer.getAddress();
 
-    const body = { address, name, symbol, standard };
+    const body = { address, name, symbol };
     const trailingUrl = 'native';
     const { nftId, txBody, appId } = await this.sendRequest(HttpMethod.POST, trailingUrl, body);
     const txHash = await this.ain.sendTransaction(txBody);
@@ -61,7 +52,6 @@ export default class Nft extends FactoryBase {
     console.log(`txHash: `, txHash);
 
     await this.register(nftId);
-
     return this.get(nftId);
   }
 

--- a/src/nft.ts
+++ b/src/nft.ts
@@ -26,6 +26,7 @@ import {
   UploadAssetFromBufferParams,
   UploadAssetFromDataUrlParams,
   SearchOption,
+  SearchReponse,
 } from './types';
 import Ainft721 from './ainft721';
 import stringify from 'fast-json-stable-stringify';
@@ -268,7 +269,7 @@ export default class Nft extends FactoryBase {
    * @returns
    * @param {NftSearchParams & SearchOption} searchParams
    */
-  searchCollections(searchParams: NftSearchParams & SearchOption) {
+  searchCollections(searchParams: NftSearchParams & SearchOption): Promise<SearchReponse> {
     let query: Record<string, any> = {};
     if (searchParams) {
       const { userAddress, nftId, name, symbol, limit, offset } = searchParams;
@@ -282,7 +283,7 @@ export default class Nft extends FactoryBase {
    * Search nft assets on the ain blockchain.
    * @param {NftSearchParams & SearchOption} searchParams
    */
-  searchAssets(searchParams: NftSearchParams & SearchOption) {
+  searchAssets(searchParams: NftSearchParams & SearchOption): Promise<SearchReponse> {
     let query: Record<string, any> = {};
     if (searchParams) {
       const { userAddress, nftId, name, symbol, limit, offset, tokenId } = searchParams;

--- a/src/nft.ts
+++ b/src/nft.ts
@@ -48,7 +48,7 @@ export default class Nft extends FactoryBase {
     if (!this.isSupportedStandard(standard)) {
       throw Error('Nft create: Not supported standard.');
     }
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     const body = { address, name, symbol, standard };
     const trailingUrl = 'native';
@@ -62,7 +62,7 @@ export default class Nft extends FactoryBase {
 
     await this.register(nftId);
 
-    return this.getAinft721(nftId);
+    return this.get(nftId);
   }
 
   /**
@@ -71,7 +71,7 @@ export default class Nft extends FactoryBase {
    * @returns 
    */
   async register(nftId: string) {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
     const message = stringify({
       address,
       timestamp: Date.now(),
@@ -84,10 +84,10 @@ export default class Nft extends FactoryBase {
   }
 
   /**
-   * Return Ainft721 instance by nftId.
+   * Return Ainft instance by nftId.
    * @param nftId
    */
-  getAinft721(nftId: string) {
+  get(nftId: string) {
     return new Ainft721(nftId, this.ain, this.baseUrl);
   }
 
@@ -265,7 +265,7 @@ export default class Nft extends FactoryBase {
       const trailingUrl = `info/${chain}/${network}/${contractAddress}/${tokenId}/metadata`;
       return this.sendRequest(HttpMethod.POST, trailingUrl, body);
     } else {
-      const address = this.ain.signer.getAddress();
+      const address = await this.ain.signer.getAddress();
       const txBody = await this.getTxBodyForSetNftMetadata({
         nftId,
         tokenId,

--- a/src/nft.ts
+++ b/src/nft.ts
@@ -87,8 +87,13 @@ export default class Nft extends FactoryBase {
    * Return Ainft instance by nftId.
    * @param nftId
    */
-  get(nftId: string) {
-    return new Ainft721(nftId, this.ain, this.baseUrl);
+  async get(nftId: string) {
+    const { list } = await this.searchCollections({ nftId });
+    if (list.length === 0) {
+      throw new Error(`Not found ainft`);
+    }
+    const nft = list[0];
+    return new Ainft721({ id: nft.id, name: nft.name, symbol: nft.symbol, owner: nft.owner }, this.ain, this.baseUrl);
   }
 
   /**
@@ -298,7 +303,7 @@ export default class Nft extends FactoryBase {
    * @returns
    * @param {NftSearchParams & SearchOption} searchParams
    */
-  searchCollections(searchParams: NftSearchParams & SearchOption): Promise<NftToken[]> {
+  searchCollections(searchParams: NftSearchParams & SearchOption) {
     let query: Record<string, any> = {};
     if (searchParams) {
       const { userAddress, nftId, name, symbol, limit, offset } = searchParams;

--- a/src/types.ts
+++ b/src/types.ts
@@ -863,3 +863,25 @@ export interface getTxbodyAddAiHistoryParams {
 }
 
 export interface AddAiHistoryParams extends Omit<getTxbodyAddAiHistoryParams, 'address'> {};
+
+export interface AinftCollectionSearch {
+  id: string;
+  name: string;
+  symbol: string;
+  owner: string;
+  standard: string;
+}
+
+export interface AinftTokenSearch {
+  tokenId: string;
+  owner: string;
+  tokenURI: string;
+  metadata?: object;
+  collectionInfo: AinftCollectionSearch;
+}
+
+export interface SearchReponse {
+  list: Array<AinftCollectionSearch | AinftTokenSearch>,
+  isFinal: boolean;
+  nextOffset: string;
+}


### PR DESCRIPTION
issue
- https://www.notion.so/comcom/ainft-js-getAinft721-get-45d8cd840be94ebf84cf2853359d2145?pvs=4
- https://www.notion.so/comcom/ainft-js-setNftMetadata-9c74f11dee3d42a89f2bddfc5a49098d?pvs=4

Updates
- Add setAinWalletSigner function.
    - User doesn't need to know AinWalletSigner object from ain-js.
- Update `getAinft721` to `get`.
    - Add logic to check that nft exists
- Update setNftMetadata.
    - Remove logic for ainft and Add AinftToken with setMetadata func.
- Add sendRequestWithoutSign.
    - APIs that make txBody don't need signing.