### PR TITLE
Upgrade node minimum version to 16

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 14, 16 ]
+        node: [ 16, 18 ]
     name: Run Test on Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 14, 16 ]
+        node: [ 16, 18 ]
     name: Run Test on Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "types": "dist/ainft.d.ts",
   "version": "1.0.0",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc",


### PR DESCRIPTION
### Summary
- upgraded the minimum Node.js version of `ainft-js` to 16 due to the dependency on `ainize-sdk`(>=16).
- modified the Github Actions workflow(run_test) to disable 14 and enable 18.