### PR TITLE
[ChatAI] Create message

### DIFF
--- a/src/ai/threads/messages/message.ts
+++ b/src/ai/threads/messages/message.ts
@@ -148,27 +148,27 @@ export default class Messages {
     return buildSetValueTransactionBody(messagesRef, data);
   }
 
-  private waitForRun(threadId: string, runId: string) {
-    return new Promise<void>((resolve, reject) => {
-      const interval = setInterval(async () => {
-        // TODO(jiyoung): replace with ainize.request() method.
-        const run = await this.openai.beta.threads.runs.retrieve(
-          threadId,
-          runId
-        );
-        if (run.status === 'completed') {
-          clearInterval(interval);
-          resolve();
-        }
-        if (
-          run.status === 'expired' ||
-          run.status === 'failed' ||
-          run.status === 'cancelled'
-        ) {
-          clearInterval(interval);
-          reject(new Error(`Run ${runId} is ${run.status}`));
-        }
-      }, 1000); // 1s
-    });
-  }
+  // private waitForRun(threadId: string, runId: string) {
+  //   return new Promise<void>((resolve, reject) => {
+  //     const interval = setInterval(async () => {
+  //       // TODO(jiyoung): replace with ainize.request() method.
+  //       const run = await this.openai.beta.threads.runs.retrieve(
+  //         threadId,
+  //         runId
+  //       );
+  //       if (run.status === 'completed') {
+  //         clearInterval(interval);
+  //         resolve();
+  //       }
+  //       if (
+  //         run.status === 'expired' ||
+  //         run.status === 'failed' ||
+  //         run.status === 'cancelled'
+  //       ) {
+  //         clearInterval(interval);
+  //         reject(new Error(`Run ${runId} is ${run.status}`));
+  //       }
+  //     }, 1000); // 1s
+  //   });
+  // }
 }

--- a/src/ai/threads/messages/message.ts
+++ b/src/ai/threads/messages/message.ts
@@ -1,0 +1,105 @@
+import Ain from '@ainblockchain/ain-js';
+import Ainize from '@ainize-team/ainize-js';
+
+import Ainft721Object from '../../../ainft721Object';
+import {
+  MessageCreateParams,
+  MessageTransactionResult,
+  ThreadMessage,
+} from '../../../types';
+import {
+  Ref,
+  buildSetValueTransactionBody,
+  validateAiConfig,
+  validateAndGetAiName,
+  validateAndGetTokenAi,
+  validateObject,
+  validateThread,
+  validateToken,
+} from '../../../util';
+
+export default class Messages {
+  private ain: Ain;
+  private ainize: Ainize;
+
+  constructor(ain: Ain, ainize: Ainize) {
+    this.ain = ain;
+    this.ainize = ainize;
+  }
+
+  async create(
+    threadId: string,
+    {
+      objectId,
+      tokenId,
+      provider,
+      api,
+      role,
+      content,
+      metadata,
+    }: MessageCreateParams
+  ): Promise<MessageTransactionResult> {
+    const appId = Ainft721Object.getAppId(objectId);
+    const address = this.ain.signer.getAddress();
+
+    await validateObject(appId, this.ain);
+    await validateToken(appId, tokenId, this.ain);
+
+    const aiName = validateAndGetAiName(provider, api);
+    await validateAiConfig(appId, aiName, this.ain);
+    await validateAndGetTokenAi(appId, tokenId, aiName, null, this.ain);
+
+    await validateThread(appId, tokenId, aiName, address, threadId, this.ain);
+
+    const message = <ThreadMessage>{
+      id: 'msg_000000000000000000000001',
+      thread_id: 'thread_000000000000000000000001',
+      role: 'user',
+      content: [{ type: 'text', text: content }],
+      assistant_id: null,
+      run_id: null,
+      metadata: metadata || {},
+      created_at: 0,
+    };
+
+    const txBody = this.getMessageCreateTxBody(
+      appId,
+      tokenId,
+      aiName,
+      address,
+      message
+    );
+
+    const txResult = await this.ain.sendTransaction(txBody);
+    return { ...txResult, message };
+  }
+
+  private getMessageCreateTxBody(
+    appId: string,
+    tokenId: string,
+    aiName: string,
+    address: string,
+    message: ThreadMessage
+  ) {
+    const content =
+      message.content[0].type === 'text'
+        ? message.content[0].text
+        : message.content[0].image_file;
+
+    const messageRef = Ref.app(appId)
+      .token(tokenId)
+      .ai(aiName)
+      .history(address)
+      .thread(message.thread_id)
+      .message(message.id);
+
+    return buildSetValueTransactionBody(messageRef, {
+      role: message.role,
+      content: content,
+      ...(message.metadata &&
+        !(Object.keys(message.metadata).length === 0) && {
+          metadata: message.metadata,
+        }),
+    });
+  }
+}

--- a/src/ai/threads/threads.ts
+++ b/src/ai/threads/threads.ts
@@ -2,6 +2,7 @@ import Ain from '@ainblockchain/ain-js';
 import Ainize from '@ainize-team/ainize-js';
 
 import Ainft721Object from '../../ainft721Object';
+import Messages from './messages/message';
 import {
   Thread,
   ThreadCreateParams,
@@ -26,10 +27,12 @@ import {
 export default class Threads {
   private ain: Ain;
   private ainize: Ainize;
+  messages: Messages;
 
   constructor(ain: Ain, ainize: Ainize) {
     this.ain = ain;
     this.ainize = ainize;
+    this.messages = new Messages(ain, ainize);
   }
 
   async create({
@@ -55,8 +58,11 @@ export default class Threads {
         messages?.map<ThreadMessage>((el, i) => {
           return {
             id: 'msg_' + String(i + 1).padStart(24, '0'),
-            content: el.content,
+            thread_id: 'thread_000000000000000000000001',
             role: 'user',
+            content: [{ type: 'text', text: el.content }],
+            assistant_id: null,
+            run_id: null,
             metadata: el.metadata || {},
             created_at: 0,
           };
@@ -195,7 +201,13 @@ export default class Threads {
   ) {
     const messages: { [key: string]: object } = {};
     thread.messages.forEach((msg) => {
-      messages[msg.id] = { content: msg.content, role: msg.role };
+      messages[msg.id] = {
+        role: msg.role,
+        content:
+          msg.content[0].type === 'text'
+            ? msg.content[0].text
+            : msg.content[0].image_file,
+      };
     });
 
     const threadRef = Ref.app(appId)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1136,7 +1136,7 @@ export interface ThreadDeleteTransactionResult extends TransactionResult {
 }
 
 export interface MessageTransactionResult extends TransactionResult {
-  message: ThreadMessage;
+  messages: Array<ThreadMessage>;
 }
 
 interface ChatConfigureParamsBase {
@@ -1254,16 +1254,7 @@ export interface ThreadDeleted {
 
 interface ThreadCreateParamsBase {
   tokenId: string;
-  messages?: Array<ThreadCreateParams.Message>;
   metadata?: object | null;
-}
-
-export namespace ThreadCreateParams {
-  export interface Message {
-    content: string;
-    role: 'user';
-    metadata?: object | null;
-  }
 }
 
 export interface OpenAIThreadCreateParams extends ThreadCreateParamsBase {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1135,6 +1135,10 @@ export interface ThreadDeleteTransactionResult extends TransactionResult {
   delThread: ThreadDeleted;
 }
 
+export interface MessageTransactionResult extends TransactionResult {
+  message: ThreadMessage;
+}
+
 interface ChatConfigureParamsBase {
   objectId: string;
 }
@@ -1224,10 +1228,23 @@ export interface Thread {
 
 export interface ThreadMessage {
   id: string;
-  content: string;
+  thread_id: string;
   role: 'user' | 'assistant';
+  content: Array<MessageContentText | MessageContentImageFile>;
+  assistant_id: string | null;
+  run_id: string | null;
   metadata: object | null;
   created_at: number;
+}
+
+export interface MessageContentText {
+  type: 'text';
+  text: string;
+}
+
+export interface MessageContentImageFile {
+  type: 'image_file';
+  image_file: string;
 }
 
 export interface ThreadDeleted {
@@ -1275,3 +1292,14 @@ export interface OpenAIThreadDeleteParams extends ThreadDeleteParamsBase {
 }
 
 export type ThreadDeleteParams = OpenAIThreadDeleteParams;
+
+interface MessageCreateParamsBase {
+  tokenId: string;
+  role: 'user';
+  content: string;
+  metadata?: object | null;
+}
+
+export interface OpenAIMessageCreateParams extends MessageCreateParamsBase, OpenAIChatConfigureParams {}
+
+export type MessageCreateParams = OpenAIMessageCreateParams;

--- a/src/util.ts
+++ b/src/util.ts
@@ -115,7 +115,7 @@ export const Ref = {
                           .token(tokenId)
                           .ai(aiName)
                           .history(address)
-                          .thread(threadId)}/messages/${messageId}`,
+                          .thread(threadId).root()}/messages/${messageId}`,
                     };
                   },
                 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -110,12 +110,19 @@ export const Ref = {
                           .ai(aiName)
                           .history(address)
                           .root()}/threads/${threadId}`,
+                      messages: () =>
+                        `${Ref.app(appId)
+                          .token(tokenId)
+                          .ai(aiName)
+                          .history(address)
+                          .root()}/threads/${threadId}/messages`,
                       message: (messageId: string) =>
                         `${Ref.app(appId)
                           .token(tokenId)
                           .ai(aiName)
                           .history(address)
-                          .thread(threadId).root()}/messages/${messageId}`,
+                          .thread(threadId)
+                          .root()}/messages/${messageId}`,
                     };
                   },
                 };
@@ -152,6 +159,7 @@ type HistoryRef = {
 
 type ThreadRef = {
   root: () => string;
+  messages: () => string;
   message: (messageId: string) => string;
 };
 

--- a/test/ai/threads/messages/messages.test.ts
+++ b/test/ai/threads/messages/messages.test.ts
@@ -1,0 +1,37 @@
+import AinftJs from '../../../../src/ainft';
+
+const ainft = new AinftJs(process.env['PRIVATE_KEY']!, {
+  ainftServerEndpoint: 'https://ainft-api-dev.ainetwork.ai',
+  ainBlockchainEndpoint: 'https://testnet-api.ainetwork.ai',
+  chainId: 0,
+});
+
+const objectId = '0x45E89F37Cee508cf0D4F6e74b35EfeBdd90BD731';
+const appId = 'ainft721_0x45e89f37cee508cf0d4f6e74b35efebdd90bd731';
+const aiName = 'ainize_test14';
+const tokenId = '3';
+const address = '0x7ed9c30C9F3A31Daa9614b90B4a710f61Bd585c0';
+const threadId = 'thread_000000000000000000000001';
+const messageId = 'msg_000000000000000000000001';
+
+describe('Message', () => {
+  it('create: should create message', async () => {
+    const txResult = await ainft.ai.chat.threads.messages.create(threadId, {
+      objectId,
+      tokenId,
+      provider: 'openai',
+      api: 'assistants',
+      role: 'user',
+      content: 'hello',
+    });
+
+    const message = await ainft.ain.db
+      .ref(`/apps/${appId}/tokens/${tokenId}/ai/${aiName}/history/${address}/threads/${threadId}/messages/${messageId}`)
+      .getValue();
+
+    expect(txResult.tx_hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+    expect(txResult.result).toBeDefined();
+    expect(message.role).toBe('user');
+    expect(message.content).toBe('hello');
+  });
+});

--- a/test/ai/threads/messages/messages.test.ts
+++ b/test/ai/threads/messages/messages.test.ts
@@ -25,13 +25,12 @@ describe('Message', () => {
       content: 'hello',
     });
 
-    const message = await ainft.ain.db
-      .ref(`/apps/${appId}/tokens/${tokenId}/ai/${aiName}/history/${address}/threads/${threadId}/messages/${messageId}`)
+    const messages = await ainft.ain.db
+      .ref(`/apps/${appId}/tokens/${tokenId}/ai/${aiName}/history/${address}/threads/${threadId}/messages`)
       .getValue();
 
     expect(txResult.tx_hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
     expect(txResult.result).toBeDefined();
-    expect(message.role).toBe('user');
-    expect(message.content).toBe('hello');
-  });
+    expect(Object.keys(messages).length).toBe(2);
+  }, 10000);
 });

--- a/test/ai/threads/threads.test.ts
+++ b/test/ai/threads/threads.test.ts
@@ -36,10 +36,6 @@ describe('Thread', () => {
         api: 'assistants',
       },
       tokenId: tokenId,
-      messages: [
-        { content: 'hello', role: 'user' },
-        { content: 'nice to meet you', role: 'user' },
-      ],
       metadata: { key: 'value' },
     });
 
@@ -50,7 +46,6 @@ describe('Thread', () => {
     expect(txResult.tx_hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
     expect(txResult.result).toBeDefined();
     expect(thread).not.toBeNull();
-    expect(Object.keys(thread.messages).length).toBe(2);
     expect(thread.metadata).toEqual({ key: 'value' });
   });
 
@@ -86,7 +81,6 @@ describe('Thread', () => {
 
     expect(txResult.tx_hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
     expect(txResult.result).toBeDefined();
-    expect(Object.keys(thread.messages).length).toBe(2);
     expect(thread.metadata).toEqual({ key1: 'value1', key2: 'value2' });
   });
 


### PR DESCRIPTION
- Add create `message` and test code.
- Execute `run` when message is created. ([link](https://platform.openai.com/docs/assistants/how-it-works/runs-and-run-steps))
- In AINFT, unlike OpenAI where 'message' and 'run' are separate. but I've implemented automatic run execution upon message creation for immediate assistant response messages.
- Call flow in `message.create()`: Create Message -> Create Run -> Check Run Status (polling) -> Retrieve Message list.