### PR TITLE
Add signer support

### DIFF
--- a/src/ai/assistant.ts
+++ b/src/ai/assistant.ts
@@ -59,7 +59,7 @@ export class Assistants extends FactoryBase {
     tokenId: string,
     { model, name, instructions, description, metadata }: AssistantCreateParams
   ): Promise<AssistantTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     const isAdmin = await isObjectOwner(this.ain, objectId, address);
@@ -108,7 +108,7 @@ export class Assistants extends FactoryBase {
     assistantId: string,
     { model, name, instructions, description, metadata }: AssistantUpdateParams
   ): Promise<AssistantTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     const isAdmin = await isObjectOwner(this.ain, objectId, address);
@@ -156,7 +156,7 @@ export class Assistants extends FactoryBase {
     tokenId: string,
     assistantId: string
   ): Promise<AssistantDeleteTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     const isAdmin = await isObjectOwner(this.ain, objectId, address);
@@ -211,7 +211,7 @@ export class Assistants extends FactoryBase {
   }
 
   async list(objectId: string, { limit = 20, offset = 0, order = 'desc' }: QueryParams) {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
 

--- a/src/ai/chat.ts
+++ b/src/ai/chat.ts
@@ -29,7 +29,7 @@ export class Chat extends FactoryBase {
    * @returns {Promise<ChatConfigurationTransactionResult>} Returns a promise that resolves with both the transaction result and the chat configuration.
    */
   async configure(objectId: string, nickname: string): Promise<ChatConfigurationTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateObjectOwner(this.ain, objectId, address);
@@ -56,7 +56,7 @@ export class Chat extends FactoryBase {
    */
   /*
   async depositCredit(nickname: ServiceNickname, amount: number): Promise<CreditTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     const serviceName = await validateAndGetServiceName(nickname, this.ainize);
     const service = await validateAndGetService(serviceName, this.ainize);

--- a/src/ai/message.ts
+++ b/src/ai/message.ts
@@ -45,7 +45,7 @@ export class Messages extends FactoryBase {
     body: MessageCreateParams
   ): Promise<MessagesTransactionResult> {
     const appId = AinftObject.getAppId(objectId);
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);
@@ -80,7 +80,7 @@ export class Messages extends FactoryBase {
     messageId: string,
     { metadata }: MessageUpdateParams
   ): Promise<MessageTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);
@@ -124,7 +124,7 @@ export class Messages extends FactoryBase {
     threadId: string,
     messageId: string
   ): Promise<Message> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);
@@ -157,7 +157,7 @@ export class Messages extends FactoryBase {
    */
   async list(objectId: string, tokenId: string, threadId: string): Promise<MessageMap> {
     const appId = AinftObject.getAppId(objectId);
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);

--- a/src/ai/thread.ts
+++ b/src/ai/thread.ts
@@ -43,7 +43,7 @@ export class Threads extends FactoryBase {
     tokenId: string,
     { metadata }: ThreadCreateParams
   ): Promise<ThreadTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);
@@ -83,7 +83,7 @@ export class Threads extends FactoryBase {
     threadId: string,
     { metadata }: ThreadUpdateParams
   ): Promise<ThreadTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);
@@ -123,7 +123,7 @@ export class Threads extends FactoryBase {
     tokenId: string,
     threadId: string
   ): Promise<ThreadDeleteTransactionResult> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);
@@ -156,7 +156,7 @@ export class Threads extends FactoryBase {
    * @returns Returns a promise that resolves with the thread.
    */
   async get(objectId: string, tokenId: string, threadId: string): Promise<Thread> {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);
@@ -183,7 +183,7 @@ export class Threads extends FactoryBase {
     tokenId: string,
     { limit = 20, offset = 0, order = 'desc' }: QueryParams
   ) {
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);
@@ -226,7 +226,7 @@ export class Threads extends FactoryBase {
     { metadata, messages }: ThreadCreateAndRunParams
   ) {
     const appId = AinftObject.getAppId(objectId);
-    const address = this.ain.signer.getAddress();
+    const address = await this.ain.signer.getAddress();
 
     await validateObject(this.ain, objectId);
     await validateToken(this.ain, objectId, tokenId);

--- a/src/ainft.ts
+++ b/src/ainft.ts
@@ -45,7 +45,8 @@ export default class AinftJs {
   public message: Messages;
 
   constructor(
-    privateKey: string,
+    privateKey?: string | null,
+    signer?: Signer | null,
     config?: {
       ainftServerEndpoint?: string,
       ainBlockchainEndpoint?: string,
@@ -62,7 +63,15 @@ export default class AinftJs {
     }
 
     this.ain = new Ain(_.get(config, 'ainBlockchainEndpoint') || AIN_BLOCKCHAIN_ENDPOINT[stage], chainId);
-    this.setPrivateKey(privateKey);
+    this.ainize = new Ainize(chainId);
+
+    if (privateKey) {
+      this.setPrivateKey(privateKey);
+    } else if (signer) {
+      this.setSigner(signer);
+    } else {
+      throw new Error('You must use either a private key or a signer.');
+    }
 
     this.nft = new Nft(this.ain, this.baseUrl, '/nft');
     this.eth = new Eth(this.ain, this.baseUrl, '/nft');

--- a/src/ainft.ts
+++ b/src/ainft.ts
@@ -63,7 +63,6 @@ export default class AinftJs {
     }
 
     this.ain = new Ain(_.get(config, 'ainBlockchainEndpoint') || AIN_BLOCKCHAIN_ENDPOINT[stage], chainId);
-    this.ainize = new Ainize(chainId);
 
     if (privateKey) {
       this.setPrivateKey(privateKey);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -46,7 +46,8 @@ export const buildSetTxBody = (
 
 export const sendTx = async (ain: Ain, txBody: any) => {
   const result = await ain.sendTransaction(txBody);
-  // NOTE(jiyoung): only txHash is returned when sending transaction via signer.
+  // NOTE(jiyoung): request AIN Wallet's owner to add result code.
+  // ref) https://github.com/ainblockchain/ain-blockchain/blob/master/JSON_RPC_API.md#ain_sendsignedtransaction
   // if (!isTransactionSuccess(result)) {
   //   throw new Error(`Transaction failed: ${JSON.stringify(result)}`);
   // }

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -46,9 +46,10 @@ export const buildSetTxBody = (
 
 export const sendTx = async (ain: Ain, txBody: any) => {
   const result = await ain.sendTransaction(txBody);
-  if (!isTransactionSuccess(result)) {
-    throw new Error(`Transaction failed: ${JSON.stringify(result)}`);
-  }
+  // NOTE(jiyoung): only txHash is returned when sending transaction via signer.
+  // if (!isTransactionSuccess(result)) {
+  //   throw new Error(`Transaction failed: ${JSON.stringify(result)}`);
+  // }
   return result;
 };
 

--- a/test/ai/assistant.test.ts
+++ b/test/ai/assistant.test.ts
@@ -6,7 +6,7 @@ describe.skip('assistant', () => {
   let ainft: AinftJs;
 
   beforeEach(() => {
-    ainft = new AinftJs(privateKey, {
+    ainft = new AinftJs(privateKey, null, {
       ainftServerEndpoint: 'https://ainft-api-dev.ainetwork.ai',
       ainBlockchainEndpoint: 'https://testnet-api.ainetwork.ai',
       chainId: 0,

--- a/test/ai/chat.test.ts
+++ b/test/ai/chat.test.ts
@@ -6,7 +6,7 @@ describe.skip('chat', () => {
   let ainft: AinftJs;
 
   beforeEach(() => {
-    ainft = new AinftJs(privateKey, {
+    ainft = new AinftJs(privateKey, null, {
       ainftServerEndpoint: 'https://ainft-api-dev.ainetwork.ai',
       ainBlockchainEndpoint: 'https://testnet-api.ainetwork.ai',
       chainId: 0,

--- a/test/ai/message.test.ts
+++ b/test/ai/message.test.ts
@@ -8,7 +8,7 @@ describe.skip('message', () => {
   let ainft: AinftJs;
 
   beforeEach(async () => {
-    ainft = new AinftJs(privateKey, {
+    ainft = new AinftJs(privateKey, null, {
       ainftServerEndpoint: 'https://ainft-api-dev.ainetwork.ai',
       ainBlockchainEndpoint: 'https://testnet-api.ainetwork.ai',
       chainId: 0,

--- a/test/ai/thread.test.ts
+++ b/test/ai/thread.test.ts
@@ -6,7 +6,7 @@ describe.skip('thread', () => {
   let ainft: AinftJs;
 
   beforeEach(async () => {
-    ainft = new AinftJs(privateKey, {
+    ainft = new AinftJs(privateKey, null, {
       ainftServerEndpoint: 'https://ainft-api-dev.ainetwork.ai',
       ainBlockchainEndpoint: 'https://testnet-api.ainetwork.ai',
       chainId: 0,

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -1,17 +1,14 @@
 import AinftJs from '../src/ainft';
 
-describe("Status", () => {
-  it("should return health", async () => {
+describe('Status', () => {
+  it('should return health', async () => {
     // TODO(hyeonwoong): remove dev api endpoint.
     const config = {
       ainftServerEndpoint: 'https://ainft-api-dev.ainetwork.ai',
       ainBlockchainEndpoint: 'https://testnet-api.ainetwork.ai',
-      chainId: 0
-    }
-    const ainftJs = new AinftJs(
-      'a'.repeat(64),
-      config,
-    );
+      chainId: 0,
+    };
+    const ainftJs = new AinftJs('a'.repeat(64), null, config);
     expect(await ainftJs.getStatus()).toMatchObject({ health: true });
   });
 });


### PR DESCRIPTION
## Summary
- Added signer support when initializing the sdk.
```javascript
import { AinWalletSigner } from '@ainblockchain/ain-js/lib/signer/ain-wallet-signer';

const signer = new AinWalletSigner();
const ainft = new AinftJs(null, signer, { ... });
```

- Patched _ain-js_ event handler has been confirmed in the browser. (see video)
- Added await to `ain.signer.getAddress` in a browser, returned a promise.
- Disabled transaction success check, because returned only txHash not code when transaction is sent via the signer.

https://github.com/ainft-team/ainft-js/assets/122012800/3a8db7b9-a6a7-4d8f-94a1-1a0654bcc4f6

