### PR TITLE
[bugfix] add missing parameters.

### DIFF
--- a/src/ainft721Object.ts
+++ b/src/ainft721Object.ts
@@ -19,6 +19,8 @@ export default class Ainft721Object extends FactoryBase {
   readonly appId: string;
   /** The metadata of AINFT object. */
   readonly metadata?: Metadata;
+  /** The URL slug of AINFT object. */
+  readonly slug?: string | null;
 
   /**
    * Constructor of Ainft721Object.
@@ -29,6 +31,7 @@ export default class Ainft721Object extends FactoryBase {
    * @param objectInfo.symbol The symbol of AINFT object.
    * @param objectInfo.owner The owner of AINFT object.
    * @param objectInfo.metadata The metadata of AINFT object.
+   * @param objectInfo.slug The URL slug of AINFT object.
    * @param ain Ain instance to sign and send transaction to AIN blockchain.
    * @param baseUrl The base url to request api to AINFT factory server.
    */
@@ -39,6 +42,7 @@ export default class Ainft721Object extends FactoryBase {
       symbol: string;
       owner: string;
       metadata?: Metadata;
+      slug?: string;
     },
     ain: Ain,
     baseUrl: string
@@ -50,6 +54,7 @@ export default class Ainft721Object extends FactoryBase {
     this.owner = objectInfo.owner;
     this.appId = Ainft721Object.getAppId(objectInfo.id);
     this.metadata = objectInfo.metadata || {};
+    this.slug = objectInfo.slug || null;
   }
 
   /**

--- a/src/nft.ts
+++ b/src/nft.ts
@@ -198,8 +198,8 @@ export default class Nft extends FactoryBase {
   searchAinftObjects(searchParams: NftSearchParams): Promise<AinftObjectSearchResponse> {
     let query: Record<string, any> = {};
     if (searchParams) {
-      const { userAddress, ainftObjectId, name, symbol, slug, limit, cursor } = searchParams;
-      query = { userAddress, ainftObjectId, name, symbol, slug, cursor, limit };
+      const { userAddress, ainftObjectId, name, symbol, slug, limit, cursor, order } = searchParams;
+      query = { userAddress, ainftObjectId, name, symbol, slug, cursor, limit, order };
     }
     const trailingUrl = `native/search/ainftObjects`;
     return this.sendRequest(HttpMethod.GET, trailingUrl, query);
@@ -234,8 +234,8 @@ export default class Nft extends FactoryBase {
   searchNfts(searchParams: NftSearchParams): Promise<AinftTokenSearchResponse> {
     let query: Record<string, any> = {};
     if (searchParams) {
-      const { userAddress, ainftObjectId, name, symbol, limit, cursor, tokenId } = searchParams;
-      query = { userAddress, ainftObjectId, name, symbol, cursor, limit, tokenId };
+      const { userAddress, ainftObjectId, name, symbol, slug, tokenId, limit, cursor, order } = searchParams;
+      query = { userAddress, ainftObjectId, name, symbol, slug, tokenId, limit, cursor, order };
     }
     const trailingUrl = `native/search/nfts`;
     return this.sendRequest(HttpMethod.GET, trailingUrl, query);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1031,6 +1031,7 @@ export interface MintNftParams extends Omit<getTxBodyMintNftParams, 'address'> {
 export interface SearchOption {
   limit?: number,
   cursor?: string,
+  order?: 'asc' | 'desc',
 }
 
 export interface NftSearchParams extends SearchOption {
@@ -1044,7 +1045,7 @@ export interface NftSearchParams extends SearchOption {
   name?: string;
   /** The symbol of AINFT object. */
   symbol?: string;
-  /** The URL-safe version of the name. (e.g. "My Object" -> "my-object") */
+  /** The URL slug of AINFT object. (e.g. "My Object" -> "my-object") */
   slug?: string;
 }
 


### PR DESCRIPTION
## Summary
- Add missing parameters. (slug, order)
- If you want to search ainft object by `slug` in order by `creation time`:
```typescript
const { ainftObjects } = await ainft.nft.searchAinftObjects({ slug: 'test-slug', order: 'asc' });
``` 