### PR TITLE
[feat] modify to use list parameter and add object id field.

### DIFF
--- a/src/ai/assistant.ts
+++ b/src/ai/assistant.ts
@@ -237,6 +237,7 @@ export class Assistants extends FactoryBase {
 
     const data = {
       id: assistant.id,
+      objectId,
       tokenId,
       owner: token.owner,
       model: assistant.config.model,
@@ -404,7 +405,7 @@ export class Assistants extends FactoryBase {
     const tokens: NftTokens = (await this.ain.db.ref(tokensPath).getValue()) || {};
     return Object.entries(tokens).reduce<NftToken[]>((acc, [id, token]) => {
       if (!address || token.owner === address) {
-        acc.push({ tokenId: id, ...token });
+        acc.push({ objectId, tokenId: id, ...token });
       }
       return acc;
     }, []);
@@ -422,6 +423,7 @@ export class Assistants extends FactoryBase {
   private toAssistant(data: any, numThreads: number): Assistant {
     return {
       id: data.ai.id,
+      objectId: data.objectId,
       tokenId: data.tokenId,
       owner: data.owner,
       model: data.ai.config.model,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1237,6 +1237,8 @@ export interface AiConfiguration {
 export interface Assistant {
   /** The identifier. */
   id: string;
+  /** The ID of AINFT object.  */
+  objectId: string | null;
   /** The ID of AINFT token. */
   tokenId: string | null;
   /** The owner address of AINFT token. */

--- a/test/ai/thread.test.ts
+++ b/test/ai/thread.test.ts
@@ -38,7 +38,7 @@ describe.skip('thread', () => {
   });
 
   it('should list threads', async () => {
-    const result = await ainft.thread.list(objectId, null, null, { limit: 20, offset: 0, order: 'desc' });
+    const result = await ainft.thread.list([objectId], null, null, { limit: 20, offset: 0, order: 'desc' });
 
     expect(result.items).toBeDefined();
   });


### PR DESCRIPTION
## Summary
- modify to use list parameter in `threads.list()`.
- add objectId field to response data for `threads.list()`.
- If you want to retrieve all threads in multi object:
```ts
const threads = ainft.threads.list(["object-id-1", "object-id-2"],  null, null, { order: 'desc' })
```