### PR TITLE
[feat] modify to use list parameter.

### DIFF
--- a/test/ai/assistant.test.ts
+++ b/test/ai/assistant.test.ts
@@ -50,7 +50,7 @@ describe.skip('assistant', () => {
   });
 
   it('should list assistants', async () => {
-    const result = await ainft.assistant.list(objectId, null);
+    const result = await ainft.assistant.list([objectId], null);
 
     expect(result.total).toBeDefined();
     expect(result.items).toBeDefined();


### PR DESCRIPTION
## Summary
- modify to use list parameter in `assistants.list()`.
```ts
const threads = ainft.assistants.list(["object-id-1", "object-id-2"],  null, { order: 'asc' })
```